### PR TITLE
Add Recycle Bin with soft-delete and 30-day retention

### DIFF
--- a/apps/api/src/cron/account-purge.cron.ts
+++ b/apps/api/src/cron/account-purge.cron.ts
@@ -1,5 +1,6 @@
 import cron from "node-cron";
 import { purgeExpiredAccounts } from "../services/account-closure.service.js";
+import { purgeExpiredItems } from "../services/recycle-bin.service.js";
 
 export function startAccountPurgeCron(): void {
   // Run daily at 3:00 AM UTC
@@ -9,6 +10,13 @@ export function startAccountPurgeCron(): void {
       purgeExpiredAccounts();
     } catch (err) {
       console.error("[cron] Account purge failed:", err);
+    }
+
+    console.log("[cron] Running recycle bin purge job...");
+    try {
+      purgeExpiredItems();
+    } catch (err) {
+      console.error("[cron] Recycle bin purge failed:", err);
     }
   });
   console.log("[cron] Account purge scheduled (daily at 03:00 UTC)");

--- a/apps/api/src/db/migrations/013_add_soft_delete.sql
+++ b/apps/api/src/db/migrations/013_add_soft_delete.sql
@@ -1,0 +1,4 @@
+-- Add soft-delete support (deletedAt timestamp) to Notebook, Section, and Note
+ALTER TABLE Notebook ADD COLUMN deletedAt TEXT DEFAULT NULL;
+ALTER TABLE Section ADD COLUMN deletedAt TEXT DEFAULT NULL;
+ALTER TABLE Note ADD COLUMN deletedAt TEXT DEFAULT NULL;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import searchRoutes from "./routes/search.routes.js";
 import shareRoutes from "./routes/share.routes.js";
 import imageRoutes from "./routes/image.routes.js";
 import audioRoutes from "./routes/audio.routes.js";
+import recycleBinRoutes from "./routes/recycle-bin.routes.js";
 import { requireAuth } from "./middleware/auth.middleware.js";
 import { ensureUploadDir, getUploadDir } from "./services/image.service.js";
 import { startAccountPurgeCron } from "./cron/account-purge.cron.js";
@@ -54,6 +55,7 @@ app.use("/api/v1", requireAuth, templateRoutes);
 app.use("/api/v1", requireAuth, noteRoutes);
 app.use("/api/v1", requireAuth, imageRoutes);
 app.use("/api/v1", requireAuth, audioRoutes);
+app.use("/api/v1/recycle-bin", requireAuth, recycleBinRoutes);
 app.use("/api/v1/search", requireAuth, searchRoutes);
 
 // ── Error handling (must be last) ─────────────────────────────

--- a/apps/api/src/routes/recycle-bin.routes.ts
+++ b/apps/api/src/routes/recycle-bin.routes.ts
@@ -1,0 +1,63 @@
+import { Router, Request, Response } from "express";
+import {
+  getDeletedItems,
+  restoreNotebook,
+  restoreSection,
+  restoreNote,
+  permanentlyDeleteNotebook,
+  permanentlyDeleteSection,
+  permanentlyDeleteNote,
+  emptyRecycleBin,
+} from "../services/recycle-bin.service.js";
+
+const router = Router();
+
+// GET /recycle-bin
+router.get("/", (req: Request, res: Response) => {
+  const items = getDeletedItems(req.user!.id);
+  res.json({ data: items });
+});
+
+// POST /recycle-bin/restore/notebook/:id
+router.post("/restore/notebook/:id", (req: Request, res: Response) => {
+  restoreNotebook(Number(req.params.id), req.user!.id);
+  res.json({ data: null, message: "Notebook restored" });
+});
+
+// POST /recycle-bin/restore/section/:id
+router.post("/restore/section/:id", (req: Request, res: Response) => {
+  restoreSection(Number(req.params.id), req.user!.id);
+  res.json({ data: null, message: "Section restored" });
+});
+
+// POST /recycle-bin/restore/note/:id
+router.post("/restore/note/:id", (req: Request, res: Response) => {
+  restoreNote(Number(req.params.id), req.user!.id);
+  res.json({ data: null, message: "Note restored" });
+});
+
+// DELETE /recycle-bin/notebook/:id
+router.delete("/notebook/:id", (req: Request, res: Response) => {
+  permanentlyDeleteNotebook(Number(req.params.id), req.user!.id);
+  res.json({ data: null, message: "Notebook permanently deleted" });
+});
+
+// DELETE /recycle-bin/section/:id
+router.delete("/section/:id", (req: Request, res: Response) => {
+  permanentlyDeleteSection(Number(req.params.id), req.user!.id);
+  res.json({ data: null, message: "Section permanently deleted" });
+});
+
+// DELETE /recycle-bin/note/:id
+router.delete("/note/:id", (req: Request, res: Response) => {
+  permanentlyDeleteNote(Number(req.params.id), req.user!.id);
+  res.json({ data: null, message: "Note permanently deleted" });
+});
+
+// DELETE /recycle-bin
+router.delete("/", (req: Request, res: Response) => {
+  emptyRecycleBin(req.user!.id);
+  res.json({ data: null, message: "Recycle bin emptied" });
+});
+
+export default router;

--- a/apps/api/src/services/note.service.ts
+++ b/apps/api/src/services/note.service.ts
@@ -30,7 +30,7 @@ export function getNotesBySection(sectionId: number, userId: number): NoteDto[] 
 
   const db = getDb();
   const result = db.exec(
-    'SELECT id, sectionId, title, content, "order", archivedAt, favoritedAt, shareToken, passwordHash, createdAt, updatedAt FROM Note WHERE sectionId = ? AND archivedAt IS NULL ORDER BY "order" ASC, id ASC',
+    'SELECT id, sectionId, title, content, "order", archivedAt, favoritedAt, shareToken, passwordHash, createdAt, updatedAt FROM Note WHERE sectionId = ? AND archivedAt IS NULL AND deletedAt IS NULL ORDER BY "order" ASC, id ASC',
     [sectionId]
   );
   if (result.length === 0) return [];
@@ -41,7 +41,7 @@ export function getNotesBySection(sectionId: number, userId: number): NoteDto[] 
 function getNoteRaw(id: number, userId: number): NoteDto {
   const db = getDb();
   const result = db.exec(
-    'SELECT id, sectionId, title, content, "order", archivedAt, favoritedAt, shareToken, passwordHash, createdAt, updatedAt FROM Note WHERE id = ?',
+    'SELECT id, sectionId, title, content, "order", archivedAt, favoritedAt, shareToken, passwordHash, createdAt, updatedAt FROM Note WHERE id = ? AND deletedAt IS NULL',
     [id]
   );
   if (result.length === 0 || result[0].values.length === 0) {
@@ -130,7 +130,8 @@ export function deleteNote(id: number, userId: number): void {
   getNoteRaw(id, userId); // verifies ownership
 
   const db = getDb();
-  db.run("DELETE FROM Note WHERE id = ?", [id]);
+  const now = new Date().toISOString();
+  db.run("UPDATE Note SET deletedAt = ? WHERE id = ?", [now, id]);
   saveDb();
 }
 
@@ -204,7 +205,7 @@ export function getFavoriteNotes(userId: number): FavoriteNoteDto[] {
      FROM Note n
      JOIN Section s ON s.id = n.sectionId
      JOIN Notebook nb ON nb.id = s.notebookId
-     WHERE nb.userId = ? AND n.favoritedAt IS NOT NULL AND n.archivedAt IS NULL
+     WHERE nb.userId = ? AND n.favoritedAt IS NOT NULL AND n.archivedAt IS NULL AND n.deletedAt IS NULL
      ORDER BY n.favoritedAt DESC`,
     [userId]
   );
@@ -231,7 +232,7 @@ export function getArchivedNotes(userId: number): ArchivedNoteDto[] {
      FROM Note n
      JOIN Section s ON s.id = n.sectionId
      JOIN Notebook nb ON nb.id = s.notebookId
-     WHERE nb.userId = ? AND n.archivedAt IS NOT NULL
+     WHERE nb.userId = ? AND n.archivedAt IS NOT NULL AND n.deletedAt IS NULL
      ORDER BY n.archivedAt DESC`,
     [userId]
   );
@@ -274,7 +275,7 @@ export function unshareNote(id: number, userId: number): void {
 export function getNoteByShareToken(token: string): SharedNoteDto {
   const db = getDb();
   const result = db.exec(
-    "SELECT title, content, updatedAt, archivedAt FROM Note WHERE shareToken = ?",
+    "SELECT title, content, updatedAt, archivedAt FROM Note WHERE shareToken = ? AND deletedAt IS NULL",
     [token]
   );
 
@@ -304,7 +305,7 @@ export function getSharedNotes(userId: number): SharedNoteListDto[] {
      FROM Note n
      JOIN Section s ON s.id = n.sectionId
      JOIN Notebook nb ON nb.id = s.notebookId
-     WHERE nb.userId = ? AND n.shareToken IS NOT NULL AND n.archivedAt IS NULL
+     WHERE nb.userId = ? AND n.shareToken IS NOT NULL AND n.archivedAt IS NULL AND n.deletedAt IS NULL
      ORDER BY n.updatedAt DESC`,
     [userId]
   );

--- a/apps/api/src/services/notebook.service.ts
+++ b/apps/api/src/services/notebook.service.ts
@@ -15,7 +15,7 @@ function rowToNotebook(row: unknown[]): NotebookDto {
 export function getAllNotebooks(userId: number): NotebookDto[] {
   const db = getDb();
   const result = db.exec(
-    'SELECT id, title, "order", createdAt, updatedAt FROM Notebook WHERE userId = ? ORDER BY "order" ASC, id ASC',
+    'SELECT id, title, "order", createdAt, updatedAt FROM Notebook WHERE userId = ? AND deletedAt IS NULL ORDER BY "order" ASC, id ASC',
     [userId]
   );
   if (result.length === 0) return [];
@@ -25,7 +25,7 @@ export function getAllNotebooks(userId: number): NotebookDto[] {
 export function getNotebookById(id: number, userId: number): NotebookDto {
   const db = getDb();
   const result = db.exec(
-    'SELECT id, title, "order", createdAt, updatedAt FROM Notebook WHERE id = ? AND userId = ?',
+    'SELECT id, title, "order", createdAt, updatedAt FROM Notebook WHERE id = ? AND userId = ? AND deletedAt IS NULL',
     [id, userId]
   );
   if (result.length === 0 || result[0].values.length === 0) {
@@ -82,6 +82,27 @@ export function deleteNotebook(id: number, userId: number): void {
   getNotebookById(id, userId);
 
   const db = getDb();
-  db.run("DELETE FROM Notebook WHERE id = ?", [id]);
+  const now = new Date().toISOString();
+  // Soft-delete the notebook and cascade to its sections and notes
+  db.run("UPDATE Notebook SET deletedAt = ? WHERE id = ?", [now, id]);
+  db.run("UPDATE Section SET deletedAt = ? WHERE notebookId = ? AND deletedAt IS NULL", [now, id]);
+  db.run(
+    "UPDATE Note SET deletedAt = ? WHERE sectionId IN (SELECT id FROM Section WHERE notebookId = ?) AND deletedAt IS NULL",
+    [now, id]
+  );
   saveDb();
+}
+
+/** Internal: get a notebook by id regardless of deletedAt status. Used by recycle-bin. */
+export function getNotebookByIdIncludeDeleted(id: number, userId: number): NotebookDto & { deletedAt: string | null } {
+  const db = getDb();
+  const result = db.exec(
+    'SELECT id, title, "order", createdAt, updatedAt, deletedAt FROM Notebook WHERE id = ? AND userId = ?',
+    [id, userId]
+  );
+  if (result.length === 0 || result[0].values.length === 0) {
+    throw new AppError(404, "Notebook not found", "NOT_FOUND");
+  }
+  const row = result[0].values[0];
+  return { ...rowToNotebook(row), deletedAt: (row[5] as string | null) ?? null };
 }

--- a/apps/api/src/services/recycle-bin.service.ts
+++ b/apps/api/src/services/recycle-bin.service.ts
@@ -1,0 +1,207 @@
+import { getDb, saveDb } from "../db/database.js";
+import { AppError } from "../middleware/error.middleware.js";
+import { getNotebookByIdIncludeDeleted } from "./notebook.service.js";
+import { getSectionByIdIncludeDeleted } from "./section.service.js";
+import type { RecycleBinDto, DeletedNotebookDto, DeletedSectionDto, DeletedNoteDto } from "@noteflow/shared-types";
+
+const PURGE_DAYS = 30;
+
+export function getDeletedItems(userId: number): RecycleBinDto {
+  const db = getDb();
+
+  // Deleted notebooks
+  const nbResult = db.exec(
+    `SELECT id, title, deletedAt
+     FROM Notebook
+     WHERE userId = ? AND deletedAt IS NOT NULL
+     ORDER BY deletedAt DESC`,
+    [userId]
+  );
+  const notebooks: DeletedNotebookDto[] = nbResult.length > 0
+    ? nbResult[0].values.map((row) => ({
+        id: row[0] as number,
+        title: row[1] as string,
+        deletedAt: row[2] as string,
+      }))
+    : [];
+
+  // Deleted sections whose parent notebook is NOT deleted
+  // (sections that were individually deleted, not cascade-deleted with a notebook)
+  const secResult = db.exec(
+    `SELECT s.id, s.title, s.notebookId, nb.title AS notebookTitle, s.deletedAt
+     FROM Section s
+     JOIN Notebook nb ON nb.id = s.notebookId
+     WHERE nb.userId = ? AND s.deletedAt IS NOT NULL AND nb.deletedAt IS NULL
+     ORDER BY s.deletedAt DESC`,
+    [userId]
+  );
+  const sections: DeletedSectionDto[] = secResult.length > 0
+    ? secResult[0].values.map((row) => ({
+        id: row[0] as number,
+        title: row[1] as string,
+        notebookId: row[2] as number,
+        notebookTitle: row[3] as string,
+        deletedAt: row[4] as string,
+      }))
+    : [];
+
+  // Deleted notes whose parent section AND notebook are NOT deleted
+  // (notes that were individually deleted, not cascade-deleted)
+  const noteResult = db.exec(
+    `SELECT n.id, n.title, n.sectionId, s.title AS sectionTitle,
+            s.notebookId, nb.title AS notebookTitle, n.deletedAt
+     FROM Note n
+     JOIN Section s ON s.id = n.sectionId
+     JOIN Notebook nb ON nb.id = s.notebookId
+     WHERE nb.userId = ? AND n.deletedAt IS NOT NULL AND s.deletedAt IS NULL AND nb.deletedAt IS NULL
+     ORDER BY n.deletedAt DESC`,
+    [userId]
+  );
+  const notes: DeletedNoteDto[] = noteResult.length > 0
+    ? noteResult[0].values.map((row) => ({
+        id: row[0] as number,
+        title: row[1] as string,
+        sectionId: row[2] as number,
+        sectionTitle: row[3] as string,
+        notebookId: row[4] as number,
+        notebookTitle: row[5] as string,
+        deletedAt: row[6] as string,
+      }))
+    : [];
+
+  return { notebooks, sections, notes };
+}
+
+export function restoreNotebook(id: number, userId: number): void {
+  getNotebookByIdIncludeDeleted(id, userId);
+
+  const db = getDb();
+  // Restore notebook and all its cascade-deleted children
+  db.run("UPDATE Notebook SET deletedAt = NULL WHERE id = ?", [id]);
+  db.run("UPDATE Section SET deletedAt = NULL WHERE notebookId = ?", [id]);
+  db.run(
+    "UPDATE Note SET deletedAt = NULL WHERE sectionId IN (SELECT id FROM Section WHERE notebookId = ?)",
+    [id]
+  );
+  saveDb();
+}
+
+export function restoreSection(id: number, userId: number): void {
+  const section = getSectionByIdIncludeDeleted(id, userId);
+  if (!section.deletedAt) {
+    throw new AppError(400, "Section is not deleted", "NOT_DELETED");
+  }
+
+  const db = getDb();
+  // Also restore parent notebook if it was deleted
+  const nbResult = db.exec("SELECT deletedAt FROM Notebook WHERE id = ?", [section.notebookId]);
+  if (nbResult.length > 0 && nbResult[0].values[0][0]) {
+    db.run("UPDATE Notebook SET deletedAt = NULL WHERE id = ?", [section.notebookId]);
+  }
+
+  // Restore section and its cascade-deleted notes
+  db.run("UPDATE Section SET deletedAt = NULL WHERE id = ?", [id]);
+  db.run("UPDATE Note SET deletedAt = NULL WHERE sectionId = ?", [id]);
+  saveDb();
+}
+
+export function restoreNote(id: number, userId: number): void {
+  const db = getDb();
+  const result = db.exec(
+    "SELECT id, sectionId FROM Note WHERE id = ? AND deletedAt IS NOT NULL",
+    [id]
+  );
+  if (result.length === 0 || result[0].values.length === 0) {
+    throw new AppError(404, "Deleted note not found", "NOT_FOUND");
+  }
+  const sectionId = result[0].values[0][1] as number;
+
+  // Verify ownership through section → notebook
+  const secResult = db.exec("SELECT notebookId FROM Section WHERE id = ?", [sectionId]);
+  if (secResult.length === 0 || secResult[0].values.length === 0) {
+    throw new AppError(404, "Section not found", "NOT_FOUND");
+  }
+  const notebookId = secResult[0].values[0][0] as number;
+  const nbResult = db.exec("SELECT userId, deletedAt FROM Notebook WHERE id = ?", [notebookId]);
+  if (nbResult.length === 0 || nbResult[0].values.length === 0 || nbResult[0].values[0][0] !== userId) {
+    throw new AppError(404, "Note not found", "NOT_FOUND");
+  }
+
+  // Also restore parent section and notebook if they were deleted
+  if (nbResult[0].values[0][1]) {
+    db.run("UPDATE Notebook SET deletedAt = NULL WHERE id = ?", [notebookId]);
+  }
+  const secDeletedResult = db.exec("SELECT deletedAt FROM Section WHERE id = ?", [sectionId]);
+  if (secDeletedResult.length > 0 && secDeletedResult[0].values[0][0]) {
+    db.run("UPDATE Section SET deletedAt = NULL WHERE id = ?", [sectionId]);
+  }
+
+  db.run("UPDATE Note SET deletedAt = NULL WHERE id = ?", [id]);
+  saveDb();
+}
+
+export function permanentlyDeleteNotebook(id: number, userId: number): void {
+  const nb = getNotebookByIdIncludeDeleted(id, userId);
+  if (!nb.deletedAt) {
+    throw new AppError(400, "Notebook is not in recycle bin", "NOT_DELETED");
+  }
+
+  const db = getDb();
+  db.run("DELETE FROM Notebook WHERE id = ?", [id]);
+  saveDb();
+}
+
+export function permanentlyDeleteSection(id: number, userId: number): void {
+  const section = getSectionByIdIncludeDeleted(id, userId);
+  if (!section.deletedAt) {
+    throw new AppError(400, "Section is not in recycle bin", "NOT_DELETED");
+  }
+
+  const db = getDb();
+  db.run("DELETE FROM Section WHERE id = ?", [id]);
+  saveDb();
+}
+
+export function permanentlyDeleteNote(id: number, userId: number): void {
+  const db = getDb();
+  const result = db.exec(
+    "SELECT n.id FROM Note n JOIN Section s ON s.id = n.sectionId JOIN Notebook nb ON nb.id = s.notebookId WHERE n.id = ? AND nb.userId = ? AND n.deletedAt IS NOT NULL",
+    [id, userId]
+  );
+  if (result.length === 0 || result[0].values.length === 0) {
+    throw new AppError(404, "Deleted note not found", "NOT_FOUND");
+  }
+
+  db.run("DELETE FROM Note WHERE id = ?", [id]);
+  saveDb();
+}
+
+export function emptyRecycleBin(userId: number): void {
+  const db = getDb();
+  // Delete all soft-deleted items for user (notes first due to FK)
+  db.run(
+    "DELETE FROM Note WHERE deletedAt IS NOT NULL AND sectionId IN (SELECT s.id FROM Section s JOIN Notebook nb ON nb.id = s.notebookId WHERE nb.userId = ?)",
+    [userId]
+  );
+  db.run(
+    "DELETE FROM Section WHERE deletedAt IS NOT NULL AND notebookId IN (SELECT id FROM Notebook WHERE userId = ?)",
+    [userId]
+  );
+  db.run("DELETE FROM Notebook WHERE deletedAt IS NOT NULL AND userId = ?", [userId]);
+  saveDb();
+}
+
+export function purgeExpiredItems(): void {
+  const db = getDb();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - PURGE_DAYS);
+  const cutoffStr = cutoff.toISOString();
+
+  // Purge old soft-deleted notebooks (cascade handles sections/notes via FK)
+  db.run("DELETE FROM Notebook WHERE deletedAt IS NOT NULL AND deletedAt < ?", [cutoffStr]);
+  // Purge old soft-deleted sections (cascade handles notes via FK)
+  db.run("DELETE FROM Section WHERE deletedAt IS NOT NULL AND deletedAt < ?", [cutoffStr]);
+  // Purge old soft-deleted notes
+  db.run("DELETE FROM Note WHERE deletedAt IS NOT NULL AND deletedAt < ?", [cutoffStr]);
+  saveDb();
+}

--- a/apps/api/src/services/search.service.ts
+++ b/apps/api/src/services/search.service.ts
@@ -25,6 +25,7 @@ export function searchNotes(userId: number, query: string, includeArchived: bool
   const likePattern = `%${query}%`;
 
   const archiveFilter = includeArchived ? "" : "AND n.archivedAt IS NULL";
+  const deletedFilter = "AND n.deletedAt IS NULL AND s.deletedAt IS NULL AND nb.deletedAt IS NULL";
 
   const result = db.exec(
     `SELECT n.id, n.title, n.content, n.sectionId, n.updatedAt,
@@ -36,6 +37,7 @@ export function searchNotes(userId: number, query: string, includeArchived: bool
      WHERE nb.userId = ?
        AND (n.title LIKE ? OR n.content LIKE ?)
        ${archiveFilter}
+       ${deletedFilter}
      ORDER BY n.updatedAt DESC
      LIMIT 50`,
     [userId, likePattern, likePattern]

--- a/apps/api/src/services/section.service.ts
+++ b/apps/api/src/services/section.service.ts
@@ -1,6 +1,6 @@
 import { getDb, saveDb } from "../db/database.js";
 import { AppError } from "../middleware/error.middleware.js";
-import { getNotebookById } from "./notebook.service.js";
+import { getNotebookById, getNotebookByIdIncludeDeleted } from "./notebook.service.js";
 import type { SectionDto } from "@noteflow/shared-types";
 
 function rowToSection(row: unknown[]): SectionDto {
@@ -20,7 +20,7 @@ export function getSectionsByNotebook(notebookId: number, userId: number): Secti
 
   const db = getDb();
   const result = db.exec(
-    'SELECT id, notebookId, title, "order", createdAt, updatedAt FROM Section WHERE notebookId = ? ORDER BY "order" ASC, id ASC',
+    'SELECT id, notebookId, title, "order", createdAt, updatedAt FROM Section WHERE notebookId = ? AND deletedAt IS NULL ORDER BY "order" ASC, id ASC',
     [notebookId]
   );
   if (result.length === 0) return [];
@@ -31,7 +31,7 @@ export function getSectionsByNotebook(notebookId: number, userId: number): Secti
 export function getSectionById(id: number, userId: number): SectionDto {
   const db = getDb();
   const result = db.exec(
-    'SELECT id, notebookId, title, "order", createdAt, updatedAt FROM Section WHERE id = ?',
+    'SELECT id, notebookId, title, "order", createdAt, updatedAt FROM Section WHERE id = ? AND deletedAt IS NULL',
     [id]
   );
   if (result.length === 0 || result[0].values.length === 0) {
@@ -108,6 +108,28 @@ export function deleteSection(id: number, userId: number): void {
   getSectionById(id, userId); // verifies ownership
 
   const db = getDb();
-  db.run("DELETE FROM Section WHERE id = ?", [id]);
+  const now = new Date().toISOString();
+  // Soft-delete the section and cascade to its notes
+  db.run("UPDATE Section SET deletedAt = ? WHERE id = ?", [now, id]);
+  db.run("UPDATE Note SET deletedAt = ? WHERE sectionId = ? AND deletedAt IS NULL", [now, id]);
   saveDb();
+}
+
+/** Internal: get a section by id regardless of deletedAt status. Used by recycle-bin. */
+export function getSectionByIdIncludeDeleted(id: number, userId: number): SectionDto & { deletedAt: string | null } {
+  const db = getDb();
+  const result = db.exec(
+    'SELECT id, notebookId, title, "order", createdAt, updatedAt, deletedAt FROM Section WHERE id = ?',
+    [id]
+  );
+  if (result.length === 0 || result[0].values.length === 0) {
+    throw new AppError(404, "Section not found", "NOT_FOUND");
+  }
+  const row = result[0].values[0];
+  const section = rowToSection(row);
+
+  // Verify ownership through notebook (include deleted notebooks)
+  getNotebookByIdIncludeDeleted(section.notebookId, userId);
+
+  return { ...section, deletedAt: (row[6] as string | null) ?? null };
 }

--- a/apps/api/src/services/tag.service.ts
+++ b/apps/api/src/services/tag.service.ts
@@ -17,7 +17,7 @@ export function getUserTags(userId: number): TagWithCountDto[] {
     `SELECT t.id, t.name, COUNT(nt.noteId) AS noteCount
      FROM Tag t
      LEFT JOIN NoteTag nt ON nt.tagId = t.id
-     LEFT JOIN Note n ON n.id = nt.noteId AND n.archivedAt IS NULL
+     LEFT JOIN Note n ON n.id = nt.noteId AND n.archivedAt IS NULL AND n.deletedAt IS NULL
      WHERE t.userId = ?
      GROUP BY t.id
      ORDER BY t.name COLLATE NOCASE ASC`,
@@ -48,7 +48,7 @@ export function getNotesByTag(tagId: number, userId: number): TaggedNoteDto[] {
      JOIN Note n ON n.id = nt.noteId
      JOIN Section s ON s.id = n.sectionId
      JOIN Notebook nb ON nb.id = s.notebookId
-     WHERE nt.tagId = ? AND nb.userId = ? AND n.archivedAt IS NULL
+     WHERE nt.tagId = ? AND nb.userId = ? AND n.archivedAt IS NULL AND n.deletedAt IS NULL
      ORDER BY n.updatedAt DESC`,
     [tagId, userId]
   );

--- a/apps/web/src/app/core/services/recycle-bin.service.ts
+++ b/apps/web/src/app/core/services/recycle-bin.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { ApiSuccessResponse, RecycleBinDto } from '@noteflow/shared-types';
+
+@Injectable({ providedIn: 'root' })
+export class RecycleBinService {
+  private http = inject(HttpClient);
+  private base = `${environment.apiUrl}/recycle-bin`;
+
+  getAll(): Observable<RecycleBinDto> {
+    return this.http
+      .get<ApiSuccessResponse<RecycleBinDto>>(this.base)
+      .pipe(map((r) => r.data));
+  }
+
+  restoreNotebook(id: number): Observable<void> {
+    return this.http.post<void>(`${this.base}/restore/notebook/${id}`, {});
+  }
+
+  restoreSection(id: number): Observable<void> {
+    return this.http.post<void>(`${this.base}/restore/section/${id}`, {});
+  }
+
+  restoreNote(id: number): Observable<void> {
+    return this.http.post<void>(`${this.base}/restore/note/${id}`, {});
+  }
+
+  permanentlyDeleteNotebook(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.base}/notebook/${id}`);
+  }
+
+  permanentlyDeleteSection(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.base}/section/${id}`);
+  }
+
+  permanentlyDeleteNote(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.base}/note/${id}`);
+  }
+
+  emptyAll(): Observable<void> {
+    return this.http.delete<void>(this.base);
+  }
+}

--- a/apps/web/src/app/features/shell/help-panel/help-panel.ts
+++ b/apps/web/src/app/features/shell/help-panel/help-panel.ts
@@ -203,6 +203,18 @@ import { APP_VERSION } from '../../../version';
       </section>
 
       <section class="mb-5">
+        <h3 class="mb-1.5 font-semibold text-gray-900 dark:text-gray-100">Recycle Bin</h3>
+        <p class="mb-1">When you delete a notebook, section, or note, it moves to the Recycle Bin instead of being permanently removed.</p>
+        <ul class="ml-4 list-disc space-y-0.5">
+          <li>Open the Recycle Bin from the trash icon at the bottom of the navigation rail</li>
+          <li>Deleted items are kept for <strong>30 days</strong> before automatic permanent deletion</li>
+          <li>Restore any item to put it back where it was</li>
+          <li>Permanently delete individual items, or empty the entire bin</li>
+          <li>A toast notification with an <strong>Undo</strong> button appears after every delete</li>
+        </ul>
+      </section>
+
+      <section class="mb-5">
         <h3 class="mb-1.5 font-semibold text-gray-900 dark:text-gray-100">Import &amp; Export</h3>
         <p class="mb-1">Move content in and out of NoteFlow:</p>
         <ul class="ml-4 list-disc space-y-0.5">

--- a/apps/web/src/app/features/shell/nav-rail/nav-rail.ts
+++ b/apps/web/src/app/features/shell/nav-rail/nav-rail.ts
@@ -1,8 +1,8 @@
 import { Component, input, output } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faStar, faStickyNote, faMagnifyingGlass, faShareNodes, faTags, faBoxArchive } from '@fortawesome/free-solid-svg-icons';
+import { faStar, faStickyNote, faMagnifyingGlass, faShareNodes, faTags, faBoxArchive, faTrashCan } from '@fortawesome/free-solid-svg-icons';
 
-export type ShellMode = 'favorites' | 'notes' | 'shared' | 'tags' | 'search' | 'archive';
+export type ShellMode = 'favorites' | 'notes' | 'shared' | 'tags' | 'search' | 'archive' | 'recycle-bin';
 
 @Component({
   selector: 'app-nav-rail',
@@ -62,13 +62,23 @@ export type ShellMode = 'favorites' | 'notes' | 'shared' | 'tags' | 'search' | '
       <div class="flex-1"></div>
       <button
         (click)="modeChange.emit('archive')"
-        class="mb-2 flex h-10 w-10 items-center justify-center rounded-lg transition-colors"
+        class="flex h-10 w-10 items-center justify-center rounded-lg transition-colors"
         [class]="mode() === 'archive'
           ? 'bg-white text-blue-600 shadow-sm dark:bg-gray-700 dark:text-blue-400'
           : 'text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300'"
         title="Archive"
       >
         <fa-icon [icon]="faBoxArchive" />
+      </button>
+      <button
+        (click)="modeChange.emit('recycle-bin')"
+        class="mb-2 flex h-10 w-10 items-center justify-center rounded-lg transition-colors"
+        [class]="mode() === 'recycle-bin'
+          ? 'bg-white text-blue-600 shadow-sm dark:bg-gray-700 dark:text-blue-400'
+          : 'text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300'"
+        title="Recycle Bin"
+      >
+        <fa-icon [icon]="faTrashCan" />
       </button>
     </nav>
   `,
@@ -83,4 +93,5 @@ export class NavRail {
   protected faTags = faTags;
   protected faMagnifyingGlass = faMagnifyingGlass;
   protected faBoxArchive = faBoxArchive;
+  protected faTrashCan = faTrashCan;
 }

--- a/apps/web/src/app/features/shell/note-area/note-area.ts
+++ b/apps/web/src/app/features/shell/note-area/note-area.ts
@@ -371,7 +371,8 @@ import type { NoteDto, TagDto, TagWithCountDto } from '@noteflow/shared-types';
           @if (deleting()) {
             <div class="px-4">
               <app-confirm-dialog
-                message="Delete this note?"
+                message="Move this note to the Recycle Bin?"
+                confirmLabel="Move to Recycle Bin"
                 (confirmed)="confirmDelete()"
                 (cancelled)="deleting.set(false)"
               ></app-confirm-dialog>
@@ -827,7 +828,7 @@ import type { NoteDto, TagDto, TagWithCountDto } from '@noteflow/shared-types';
               @if (deleting()) {
                 <div class="px-4">
                   <app-confirm-dialog
-                    message="Delete this note?"
+                    message="Move this note to the Recycle Bin?"
                     (confirmed)="confirmDelete()"
                     (cancelled)="deleting.set(false)"
                   ></app-confirm-dialog>

--- a/apps/web/src/app/features/shell/notebook-list/notebook-list.ts
+++ b/apps/web/src/app/features/shell/notebook-list/notebook-list.ts
@@ -101,7 +101,8 @@ import type { NotebookDto } from '@noteflow/shared-types';
 
         @if (deletingId() === nb.id) {
           <app-confirm-dialog
-            [message]="'Delete ' + nb.title + ' and all its sections?'"
+            [message]="'Move ' + nb.title + ' and all its sections to the Recycle Bin?'"
+            confirmLabel="Move to Recycle Bin"
             (confirmed)="confirmDelete(nb.id)"
             (cancelled)="deletingId.set(null)"
           ></app-confirm-dialog>

--- a/apps/web/src/app/features/shell/recycle-bin-panel/recycle-bin-panel.ts
+++ b/apps/web/src/app/features/shell/recycle-bin-panel/recycle-bin-panel.ts
@@ -1,0 +1,279 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { faBook, faLayerGroup, faStickyNote, faTrashArrowUp, faTrash, faSpinner, faTrashCan } from '@fortawesome/free-solid-svg-icons';
+import { RecycleBinService } from '../../../core/services/recycle-bin.service';
+import { ShellStateService } from '../shell-state.service';
+import { ConfirmDialog } from '../../../shared/confirm-dialog/confirm-dialog';
+import type { DeletedNotebookDto, DeletedSectionDto, DeletedNoteDto } from '@noteflow/shared-types';
+
+@Component({
+  selector: 'app-recycle-bin-panel',
+  imports: [FaIconComponent, ConfirmDialog],
+  host: { class: 'flex min-h-0 flex-1 flex-col overflow-hidden' },
+  template: `
+    <div class="flex h-full flex-col">
+      <!-- Header -->
+      <div class="flex items-center justify-between border-b border-gray-200 px-3 py-2 dark:border-gray-700">
+        <span class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Recycle Bin</span>
+        @if (totalItems() > 0) {
+          <button
+            (click)="confirmingEmpty.set(true)"
+            class="rounded p-1 text-xs text-gray-400 hover:text-red-600 dark:hover:text-red-400"
+            title="Empty recycle bin"
+          >
+            <fa-icon [icon]="faTrashCan" size="sm" />
+          </button>
+        }
+      </div>
+
+      @if (confirmingEmpty()) {
+        <div class="px-3 py-2">
+          <app-confirm-dialog
+            message="Permanently delete all items in the recycle bin? This cannot be undone."
+            confirmLabel="Empty"
+            (confirmed)="emptyBin()"
+            (cancelled)="confirmingEmpty.set(false)"
+          />
+        </div>
+      }
+
+      <!-- List -->
+      <div class="min-h-0 flex-1 overflow-y-auto">
+        @if (loading()) {
+          <div class="flex items-center justify-center gap-2 py-8 text-sm text-gray-400">
+            <fa-icon [icon]="faSpinner" class="animate-spin" />
+            Loading…
+          </div>
+        } @else if (totalItems() === 0) {
+          <div class="flex flex-col items-center justify-center gap-2 py-12 text-gray-400">
+            <fa-icon [icon]="faTrash" size="2x" class="text-gray-300 dark:text-gray-600" />
+            <p class="text-sm">Recycle bin is empty</p>
+          </div>
+        } @else {
+          <!-- Notebooks -->
+          @if (notebooks().length > 0) {
+            <div class="px-3 pt-3 pb-1">
+              <span class="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Notebooks</span>
+            </div>
+            <ul class="divide-y divide-gray-100 dark:divide-gray-700">
+              @for (nb of notebooks(); track nb.id) {
+                <li class="px-3 py-2.5">
+                  <div class="flex items-start gap-2">
+                    <fa-icon [icon]="faBook" class="mt-0.5 shrink-0 text-gray-400" size="sm" />
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm font-medium text-gray-800 dark:text-gray-100" [title]="nb.title">{{ nb.title }}</p>
+                      <p class="text-xs text-gray-400 dark:text-gray-500">{{ daysRemaining(nb.deletedAt) }}</p>
+                    </div>
+                    <div class="flex shrink-0 gap-1">
+                      <button
+                        (click)="onRestoreNotebook(nb)"
+                        class="rounded p-1 text-gray-400 hover:bg-gray-200 hover:text-green-600 dark:hover:bg-gray-700 dark:hover:text-green-400"
+                        title="Restore"
+                      >
+                        <fa-icon [icon]="faTrashArrowUp" size="sm" />
+                      </button>
+                      <button
+                        (click)="confirmingPermanentDelete.set({ type: 'notebook', id: nb.id, title: nb.title })"
+                        class="rounded p-1 text-gray-400 hover:bg-gray-200 hover:text-red-600 dark:hover:bg-gray-700 dark:hover:text-red-400"
+                        title="Delete permanently"
+                      >
+                        <fa-icon [icon]="faTrash" size="xs" />
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              }
+            </ul>
+          }
+
+          <!-- Sections -->
+          @if (sections().length > 0) {
+            <div class="px-3 pt-3 pb-1">
+              <span class="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Sections</span>
+            </div>
+            <ul class="divide-y divide-gray-100 dark:divide-gray-700">
+              @for (sec of sections(); track sec.id) {
+                <li class="px-3 py-2.5">
+                  <div class="flex items-start gap-2">
+                    <fa-icon [icon]="faLayerGroup" class="mt-0.5 shrink-0 text-gray-400" size="sm" />
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm font-medium text-gray-800 dark:text-gray-100" [title]="sec.title">{{ sec.title }}</p>
+                      <p class="truncate text-xs text-gray-500 dark:text-gray-400">{{ sec.notebookTitle }}</p>
+                      <p class="text-xs text-gray-400 dark:text-gray-500">{{ daysRemaining(sec.deletedAt) }}</p>
+                    </div>
+                    <div class="flex shrink-0 gap-1">
+                      <button
+                        (click)="onRestoreSection(sec)"
+                        class="rounded p-1 text-gray-400 hover:bg-gray-200 hover:text-green-600 dark:hover:bg-gray-700 dark:hover:text-green-400"
+                        title="Restore"
+                      >
+                        <fa-icon [icon]="faTrashArrowUp" size="sm" />
+                      </button>
+                      <button
+                        (click)="confirmingPermanentDelete.set({ type: 'section', id: sec.id, title: sec.title })"
+                        class="rounded p-1 text-gray-400 hover:bg-gray-200 hover:text-red-600 dark:hover:bg-gray-700 dark:hover:text-red-400"
+                        title="Delete permanently"
+                      >
+                        <fa-icon [icon]="faTrash" size="xs" />
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              }
+            </ul>
+          }
+
+          <!-- Notes -->
+          @if (notes().length > 0) {
+            <div class="px-3 pt-3 pb-1">
+              <span class="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Notes</span>
+            </div>
+            <ul class="divide-y divide-gray-100 dark:divide-gray-700">
+              @for (note of notes(); track note.id) {
+                <li class="px-3 py-2.5">
+                  <div class="flex items-start gap-2">
+                    <fa-icon [icon]="faStickyNote" class="mt-0.5 shrink-0 text-gray-400" size="sm" />
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm font-medium text-gray-800 dark:text-gray-100" [title]="note.title">{{ note.title }}</p>
+                      <p class="truncate text-xs text-gray-500 dark:text-gray-400">{{ note.notebookTitle }} &rsaquo; {{ note.sectionTitle }}</p>
+                      <p class="text-xs text-gray-400 dark:text-gray-500">{{ daysRemaining(note.deletedAt) }}</p>
+                    </div>
+                    <div class="flex shrink-0 gap-1">
+                      <button
+                        (click)="onRestoreNote(note)"
+                        class="rounded p-1 text-gray-400 hover:bg-gray-200 hover:text-green-600 dark:hover:bg-gray-700 dark:hover:text-green-400"
+                        title="Restore"
+                      >
+                        <fa-icon [icon]="faTrashArrowUp" size="sm" />
+                      </button>
+                      <button
+                        (click)="confirmingPermanentDelete.set({ type: 'note', id: note.id, title: note.title })"
+                        class="rounded p-1 text-gray-400 hover:bg-gray-200 hover:text-red-600 dark:hover:bg-gray-700 dark:hover:text-red-400"
+                        title="Delete permanently"
+                      >
+                        <fa-icon [icon]="faTrash" size="xs" />
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              }
+            </ul>
+          }
+        }
+
+        @if (confirmingPermanentDelete()) {
+          <div class="px-3 py-2">
+            <app-confirm-dialog
+              [message]="'Permanently delete ' + confirmingPermanentDelete()!.title + '? This cannot be undone.'"
+              confirmLabel="Delete forever"
+              (confirmed)="permanentlyDelete()"
+              (cancelled)="confirmingPermanentDelete.set(null)"
+            />
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class RecycleBinPanel implements OnInit {
+  private recycleBinSvc = inject(RecycleBinService);
+  private state = inject(ShellStateService);
+
+  protected faBook = faBook;
+  protected faLayerGroup = faLayerGroup;
+  protected faStickyNote = faStickyNote;
+  protected faTrashArrowUp = faTrashArrowUp;
+  protected faTrash = faTrash;
+  protected faTrashCan = faTrashCan;
+  protected faSpinner = faSpinner;
+
+  protected notebooks = signal<DeletedNotebookDto[]>([]);
+  protected sections = signal<DeletedSectionDto[]>([]);
+  protected notes = signal<DeletedNoteDto[]>([]);
+  protected loading = signal(false);
+  protected confirmingEmpty = signal(false);
+  protected confirmingPermanentDelete = signal<{ type: 'notebook' | 'section' | 'note'; id: number; title: string } | null>(null);
+
+  protected totalItems = () => this.notebooks().length + this.sections().length + this.notes().length;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  private load(): void {
+    this.loading.set(true);
+    this.recycleBinSvc.getAll().subscribe({
+      next: (data) => {
+        this.notebooks.set(data.notebooks);
+        this.sections.set(data.sections);
+        this.notes.set(data.notes);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  protected daysRemaining(deletedAt: string): string {
+    const deleted = new Date(deletedAt);
+    const expiry = new Date(deleted);
+    expiry.setDate(expiry.getDate() + 30);
+    const now = new Date();
+    const days = Math.max(0, Math.ceil((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)));
+    if (days === 0) return 'Expires today';
+    if (days === 1) return '1 day remaining';
+    return `${days} days remaining`;
+  }
+
+  protected onRestoreNotebook(nb: DeletedNotebookDto): void {
+    this.recycleBinSvc.restoreNotebook(nb.id).subscribe(() => {
+      this.notebooks.update((list) => list.filter((n) => n.id !== nb.id));
+      this.state.loadNotebooks();
+    });
+  }
+
+  protected onRestoreSection(sec: DeletedSectionDto): void {
+    this.recycleBinSvc.restoreSection(sec.id).subscribe(() => {
+      this.sections.update((list) => list.filter((s) => s.id !== sec.id));
+      this.state.loadNotebooks();
+    });
+  }
+
+  protected onRestoreNote(note: DeletedNoteDto): void {
+    this.recycleBinSvc.restoreNote(note.id).subscribe(() => {
+      this.notes.update((list) => list.filter((n) => n.id !== note.id));
+    });
+  }
+
+  protected permanentlyDelete(): void {
+    const item = this.confirmingPermanentDelete();
+    if (!item) return;
+    this.confirmingPermanentDelete.set(null);
+
+    switch (item.type) {
+      case 'notebook':
+        this.recycleBinSvc.permanentlyDeleteNotebook(item.id).subscribe(() => {
+          this.notebooks.update((list) => list.filter((n) => n.id !== item.id));
+        });
+        break;
+      case 'section':
+        this.recycleBinSvc.permanentlyDeleteSection(item.id).subscribe(() => {
+          this.sections.update((list) => list.filter((s) => s.id !== item.id));
+        });
+        break;
+      case 'note':
+        this.recycleBinSvc.permanentlyDeleteNote(item.id).subscribe(() => {
+          this.notes.update((list) => list.filter((n) => n.id !== item.id));
+        });
+        break;
+    }
+  }
+
+  protected emptyBin(): void {
+    this.confirmingEmpty.set(false);
+    this.recycleBinSvc.emptyAll().subscribe(() => {
+      this.notebooks.set([]);
+      this.sections.set([]);
+      this.notes.set([]);
+    });
+  }
+}

--- a/apps/web/src/app/features/shell/section-list/section-list.ts
+++ b/apps/web/src/app/features/shell/section-list/section-list.ts
@@ -116,7 +116,8 @@ import type { SectionDto } from '@noteflow/shared-types';
 
           @if (deletingId() === sec.id) {
             <app-confirm-dialog
-              [message]="'Delete ' + sec.title + ' and all its notes?'"
+              [message]="'Move ' + sec.title + ' and all its notes to the Recycle Bin?'"
+              confirmLabel="Move to Recycle Bin"
               (confirmed)="confirmDelete(sec.id)"
               (cancelled)="deletingId.set(null)"
             ></app-confirm-dialog>

--- a/apps/web/src/app/features/shell/shell-state.service.ts
+++ b/apps/web/src/app/features/shell/shell-state.service.ts
@@ -3,6 +3,8 @@ import { Observable, Subscription } from 'rxjs';
 import { NotebookService } from '../../core/services/notebook.service';
 import { SectionService } from '../../core/services/section.service';
 import { NoteService } from '../../core/services/note.service';
+import { RecycleBinService } from '../../core/services/recycle-bin.service';
+import { ToastService } from '../../shared/toast/toast.service';
 import type { NotebookDto, SectionDto, NoteDto } from '@noteflow/shared-types';
 
 @Injectable()
@@ -10,6 +12,8 @@ export class ShellStateService {
   private notebookSvc = inject(NotebookService);
   private sectionSvc = inject(SectionService);
   private noteSvc = inject(NoteService);
+  private recycleBinSvc = inject(RecycleBinService);
+  private toast = inject(ToastService);
 
   // ── Data arrays ───────────────────────────────────────────────
   readonly notebooks = signal<NotebookDto[]>([]);
@@ -137,6 +141,7 @@ export class ShellStateService {
   }
 
   deleteNotebook(id: number): void {
+    const nb = this.notebooks().find((n) => n.id === id);
     this.notebookSvc.delete(id).subscribe(() => {
       this.notebooks.update((list) => list.filter((n) => n.id !== id));
       if (this.selectedNotebookId() === id) {
@@ -146,7 +151,15 @@ export class ShellStateService {
         this.sections.set([]);
         this.notes.set([]);
       }
+      this.toast.show(
+        `"${nb?.title ?? 'Notebook'}" moved to Recycle Bin`,
+        { label: 'Undo', callback: () => this.undoDeleteNotebook(id) }
+      );
     });
+  }
+
+  private undoDeleteNotebook(id: number): void {
+    this.recycleBinSvc.restoreNotebook(id).subscribe(() => this.loadNotebooks());
   }
 
   // ── Section CRUD ──────────────────────────────────────────────
@@ -181,12 +194,26 @@ export class ShellStateService {
   }
 
   deleteSection(id: number): void {
+    const sec = this.sections().find((s) => s.id === id);
+    const nbId = this.selectedNotebookId();
     this.sectionSvc.delete(id).subscribe(() => {
       this.sections.update((list) => list.filter((s) => s.id !== id));
       if (this.selectedSectionId() === id) {
         this.selectedSectionId.set(null);
         this.selectedNoteId.set(null);
         this.notes.set([]);
+      }
+      this.toast.show(
+        `"${sec?.title ?? 'Section'}" moved to Recycle Bin`,
+        { label: 'Undo', callback: () => this.undoDeleteSection(id, nbId) }
+      );
+    });
+  }
+
+  private undoDeleteSection(id: number, notebookId: number | null): void {
+    this.recycleBinSvc.restoreSection(id).subscribe(() => {
+      if (notebookId && this.selectedNotebookId() === notebookId) {
+        this.loadSections(notebookId);
       }
     });
   }
@@ -288,10 +315,24 @@ export class ShellStateService {
   }
 
   deleteNote(id: number): void {
+    const note = this.notes().find((n) => n.id === id);
+    const secId = this.selectedSectionId();
     this.noteSvc.delete(id).subscribe(() => {
       this.notes.update((list) => list.filter((n) => n.id !== id));
       if (this.selectedNoteId() === id) {
         this.selectedNoteId.set(null);
+      }
+      this.toast.show(
+        `"${note?.title ?? 'Note'}" moved to Recycle Bin`,
+        { label: 'Undo', callback: () => this.undoDeleteNote(id, secId) }
+      );
+    });
+  }
+
+  private undoDeleteNote(id: number, sectionId: number | null): void {
+    this.recycleBinSvc.restoreNote(id).subscribe(() => {
+      if (sectionId && this.selectedSectionId() === sectionId) {
+        this.loadNotes(sectionId);
       }
     });
   }

--- a/apps/web/src/app/features/shell/shell.ts
+++ b/apps/web/src/app/features/shell/shell.ts
@@ -1,6 +1,6 @@
 import { Component, computed, effect, inject, OnInit, signal, viewChild } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faCircleQuestion, faMoon, faSun, faChevronRight, faChevronLeft, faMagnifyingGlass, faBoxArchive, faStar, faShareNodes, faTags, faGear, faPlus, faCloudArrowDown, faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons';
+import { faCircleQuestion, faMoon, faSun, faChevronRight, faChevronLeft, faMagnifyingGlass, faBoxArchive, faStar, faShareNodes, faTags, faGear, faPlus, faCloudArrowDown, faArrowRightFromBracket, faTrashCan } from '@fortawesome/free-solid-svg-icons';
 import { AuthService } from '../../core/services/auth.service';
 import { ThemeService } from '../../core/services/theme.service';
 import { ViewportService } from '../../core/services/viewport.service';
@@ -20,6 +20,9 @@ import { ArchivePanel } from './archive-panel/archive-panel';
 import { FavoritesPanel } from './favorites-panel/favorites-panel';
 import { SharedPanel } from './shared-panel/shared-panel';
 import { TagsPanel } from './tags-panel/tags-panel';
+import { RecycleBinPanel } from './recycle-bin-panel/recycle-bin-panel';
+import { ToastContainer } from '../../shared/toast/toast-container';
+import { ToastService } from '../../shared/toast/toast.service';
 import { QuickNoteDialog, type QuickNoteResult } from '../../shared/quick-note-dialog/quick-note-dialog';
 import { ReleaseNotesDialog } from '../../shared/release-notes-dialog/release-notes-dialog';
 import { PwaService } from '../../core/services/pwa.service';
@@ -27,11 +30,11 @@ import { PwaUpdateService } from '../../core/services/pwa-update.service';
 import type { SearchResultDto } from '@noteflow/shared-types';
 import { APP_VERSION } from '../../version';
 
-export type MobilePanel = 'notebooks' | 'sections' | 'notes' | 'editor' | 'search' | 'archive' | 'favorites' | 'shared' | 'tags';
+export type MobilePanel = 'notebooks' | 'sections' | 'notes' | 'editor' | 'search' | 'archive' | 'favorites' | 'shared' | 'tags' | 'recycle-bin';
 
 @Component({
   selector: 'app-shell',
-  imports: [NotebookList, SectionList, NoteArea, FaIconComponent, AboutDialog, FeedbackDialog, LegalDialog, SettingsDialog, HelpPanel, Modal, NavRail, SearchPanel, ArchivePanel, FavoritesPanel, SharedPanel, TagsPanel, QuickNoteDialog, ReleaseNotesDialog],
+  imports: [NotebookList, SectionList, NoteArea, FaIconComponent, AboutDialog, FeedbackDialog, LegalDialog, SettingsDialog, HelpPanel, Modal, NavRail, SearchPanel, ArchivePanel, FavoritesPanel, SharedPanel, TagsPanel, RecycleBinPanel, QuickNoteDialog, ReleaseNotesDialog, ToastContainer],
   providers: [ShellStateService],
   template: `
     <div class="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
@@ -189,6 +192,15 @@ export type MobilePanel = 'notebooks' | 'sections' | 'notes' | 'editor' | 'searc
             >
               <fa-icon [icon]="faBoxArchive" size="sm" />
             </button>
+            <button
+              (click)="toggleMobileRecycleBin()"
+              class="rounded p-1.5 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+              [class.text-blue-500]="mobilePanel() === 'recycle-bin'"
+              [class.dark:text-blue-400]="mobilePanel() === 'recycle-bin'"
+              title="Recycle Bin"
+            >
+              <fa-icon [icon]="faTrashCan" size="sm" />
+            </button>
             @if (pwa.canInstall()) {
               <button
                 (click)="pwa.promptInstall()"
@@ -251,6 +263,11 @@ export type MobilePanel = 'notebooks' | 'sections' | 'notes' | 'editor' | 'searc
             <!-- Archive panel -->
             <aside class="flex w-96 flex-col border-r border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
               <app-archive-panel />
+            </aside>
+          } @else if (shellMode() === 'recycle-bin' && !editorFullscreen()) {
+            <!-- Recycle bin panel -->
+            <aside class="flex w-96 flex-col border-r border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
+              <app-recycle-bin-panel />
             </aside>
           } @else {
             <!-- Left panel: Notebooks -->
@@ -352,6 +369,11 @@ export type MobilePanel = 'notebooks' | 'sections' | 'notes' | 'editor' | 'searc
                 <app-tags-panel (resultClicked)="onMobileTagNoteClicked($event)" />
               </div>
             }
+            @case ('recycle-bin') {
+              <div class="flex min-h-0 w-full flex-col bg-gray-50 dark:bg-gray-900">
+                <app-recycle-bin-panel />
+              </div>
+            }
           }
         </div>
 
@@ -387,6 +409,7 @@ export type MobilePanel = 'notebooks' | 'sections' | 'notes' | 'editor' | 'searc
     <app-settings-dialog [open]="showSettings()" (closed)="showSettings.set(false)" />
     <app-quick-note-dialog [open]="showQuickNote()" (closed)="showQuickNote.set(false)" (created)="onQuickNoteCreated($event)" />
     <app-release-notes-dialog [open]="showReleaseNotes()" (closed)="showReleaseNotes.set(false)" />
+    <app-toast-container />
   `,
 })
 export class Shell implements OnInit {
@@ -411,6 +434,7 @@ export class Shell implements OnInit {
   protected faPlus = faPlus;
   protected faCloudArrowDown = faCloudArrowDown;
   protected faArrowRightFromBracket = faArrowRightFromBracket;
+  protected faTrashCan = faTrashCan;
 
   // Desktop panel state
   protected notebooksCollapsed = signal(false);
@@ -472,6 +496,8 @@ export class Shell implements OnInit {
         return 'Shared';
       case 'tags':
         return 'Tags';
+      case 'recycle-bin':
+        return 'Recycle Bin';
     }
   });
 
@@ -479,8 +505,8 @@ export class Shell implements OnInit {
     // Auto-advance mobile panel when selections change on compact viewports
     effect(() => {
       if (!this.vp.isCompact()) return;
-      // Skip auto-advance when in search/archive/favorites/shared/tags mode — they handle navigation themselves
-      if (this.mobilePanel() === 'search' || this.mobilePanel() === 'archive' || this.mobilePanel() === 'favorites' || this.mobilePanel() === 'shared' || this.mobilePanel() === 'tags') return;
+      // Skip auto-advance when in search/archive/favorites/shared/tags/recycle-bin mode — they handle navigation themselves
+      if (this.mobilePanel() === 'search' || this.mobilePanel() === 'archive' || this.mobilePanel() === 'favorites' || this.mobilePanel() === 'shared' || this.mobilePanel() === 'tags' || this.mobilePanel() === 'recycle-bin') return;
       if (this.cameFromSearch) return;
 
       const nbId = this.state.selectedNotebookId();
@@ -626,6 +652,14 @@ export class Shell implements OnInit {
     }
   }
 
+  protected toggleMobileRecycleBin(): void {
+    if (this.mobilePanel() === 'recycle-bin') {
+      this.mobilePanel.set('notebooks');
+    } else {
+      this.mobilePanel.set('recycle-bin');
+    }
+  }
+
   protected onMobileSearchResultClicked(result: SearchResultDto): void {
     this.cameFromSearch = true;
     this.state.selectNoteFromSearch(result.notebookId, result.sectionId, result.noteId);
@@ -672,6 +706,9 @@ export class Shell implements OnInit {
         this.mobilePanel.set('notebooks');
         break;
       case 'tags':
+        this.mobilePanel.set('notebooks');
+        break;
+      case 'recycle-bin':
         this.mobilePanel.set('notebooks');
         break;
     }

--- a/apps/web/src/app/release-notes.ts
+++ b/apps/web/src/app/release-notes.ts
@@ -6,6 +6,16 @@ export interface ReleaseGroup {
 
 export const RELEASE_NOTES: ReleaseGroup[] = [
   {
+    version: '0.8.0',
+    date: '2026-03-16',
+    items: [
+      'Recycle Bin for notebooks, sections, and notes — deleted items are soft-deleted and can be restored for up to 30 days',
+      'Undo delete with a toast notification that appears after moving items to the Recycle Bin',
+      'Restore or permanently delete items from the Recycle Bin panel in the navigation rail',
+      'Empty Recycle Bin to permanently remove all deleted items at once',
+    ],
+  },
+  {
     version: '0.7.0',
     date: '2026-03-15',
     items: [

--- a/apps/web/src/app/shared/toast/toast-container.ts
+++ b/apps/web/src/app/shared/toast/toast-container.ts
@@ -1,0 +1,28 @@
+import { Component, inject } from '@angular/core';
+import { ToastService } from './toast.service';
+
+@Component({
+  selector: 'app-toast-container',
+  template: `
+    <div class="fixed bottom-12 left-1/2 z-[9999] flex -translate-x-1/2 flex-col items-center gap-2">
+      @for (toast of toastSvc.toasts(); track toast.id) {
+        <div class="flex items-center gap-3 rounded-lg bg-gray-800 px-4 py-2.5 text-sm text-white shadow-lg dark:bg-gray-700">
+          <span>{{ toast.message }}</span>
+          @if (toast.action) {
+            <button
+              (click)="toast.action!.callback(); toastSvc.dismiss(toast.id)"
+              class="font-semibold text-blue-300 hover:text-blue-200"
+            >{{ toast.action!.label }}</button>
+          }
+          <button
+            (click)="toastSvc.dismiss(toast.id)"
+            class="ml-1 text-gray-400 hover:text-white"
+          >&times;</button>
+        </div>
+      }
+    </div>
+  `,
+})
+export class ToastContainer {
+  protected toastSvc = inject(ToastService);
+}

--- a/apps/web/src/app/shared/toast/toast.service.ts
+++ b/apps/web/src/app/shared/toast/toast.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface Toast {
+  id: number;
+  message: string;
+  action?: { label: string; callback: () => void };
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  readonly toasts = signal<Toast[]>([]);
+  private nextId = 0;
+
+  show(message: string, action?: { label: string; callback: () => void }, durationMs = 5000): void {
+    const id = this.nextId++;
+    this.toasts.update((list) => [...list, { id, message, action }]);
+    setTimeout(() => this.dismiss(id), durationMs);
+  }
+
+  dismiss(id: number): void {
+    this.toasts.update((list) => list.filter((t) => t.id !== id));
+  }
+}

--- a/apps/web/src/app/version.ts
+++ b/apps/web/src/app/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.7.0';
+export const APP_VERSION = '0.8.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noteflow",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noteflow",
-      "version": "0.6.0",
+      "version": "0.8.0",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -224,7 +224,6 @@
       "integrity": "sha512-qYCWLGtEju4cDtYLi4ZzbwKoF0lcGs+Lc31kuESvAzYvWNgk2EUOtwWo8kbgpAzAwSYodtxW6Q90iWEwfU6elw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -258,7 +257,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -642,7 +640,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.1.tgz",
       "integrity": "sha512-xhv2i1Q9s1kpGbGsfj+o36+XUC/TQLcZyRuRxn3GwaN7Rv34FabC88ycpvoE+sW/txj4JRx9yPA0dRSZjwZ+Gg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -659,7 +656,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.1.tgz",
       "integrity": "sha512-FxWaSaii1vfHIFA+JksqQ8NGB2frfqCrs7Ju50a44kbwR4fmanfn/VsiS/CbwBp9vcyT/Br9X/jAG4RuK/U2nw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -672,7 +668,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.1.tgz",
       "integrity": "sha512-pFTbg03s2ZI5cHNT+eWsGjwIIKiYkeAnodFbCAHjwFi9KCEYlTykFLjr9lcpGrBddfmAH7GE08Q73vgmsdcNHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -698,7 +693,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.1.tgz",
       "integrity": "sha512-6aqOPk9xoa0dfeUDeEbhaiPhmt6MQrdn59qbGAomn9RMXA925TrHbJhSIkp9tXc2Fr4aJRi8zkD/cdXEc1IYeA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -718,7 +712,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.1.tgz",
       "integrity": "sha512-k4SJLxIaLT26vLjLuFL+ho0BiG5PrdxEsjsXFC7w5iUhomeouzkHVTZ4t7gaLNKrdRD7QNtU4Faw0nL0yx0ZPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -759,7 +752,6 @@
       "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-21.2.1.tgz",
       "integrity": "sha512-mFyEVh5KazB6wr9uoXhlDQQDaicH9/t2m6lsN+/t2y6iMPpTIuTbWYHXX1uVbLKcxne54ei78NgD3wNS7DMfmg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -860,7 +852,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1220,7 +1211,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1261,7 +1251,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1774,7 +1763,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -2156,7 +2144,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -4829,7 +4816,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.1.tgz",
       "integrity": "sha512-SwkPEWIfaDEZjC8SEIi4kZjqIYUbRgLUHUuQezo5GbphUNC8kM1pi3C3EtoOPtxXrEbY6e4pWEzW54Pcrd+rVA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4926,7 +4912,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.20.1.tgz",
       "integrity": "sha512-vKejwBq+Nlj4Ybd3qOyDxIQKzYymdNH+8eXkKwGShk2nfLJIxq69DCyGvmuHgipIO1qcYPJ149UNpGN+YGcdmA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5174,7 +5159,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.1.tgz",
       "integrity": "sha512-euBRAn0mkV7R2VEE+AuOt3R0j9RHEMFXamPFmtvTo8IInxDClusrm6mJoDjS8gCGAXsQCRiAe1SCQBPgGbOOwg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5310,7 +5294,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.20.1.tgz",
       "integrity": "sha512-y2o1De3P/FH80nst1D9pYSwtRvxF87WkNAYGurqCkZ6SjwFq1Ifeh9eY+o79R6SCwcfpvQRytCYd+Yw9o5XAtA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5416,7 +5399,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.20.1.tgz",
       "integrity": "sha512-3LQU92zX6tzl47EBskkAKeJXd6EWwYmBDE7jbd7InJqnt9NMAcj4DtXtXpI+e6Un5+8yzNjVA+fI5+5cFS3dSg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5469,7 +5451,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.1.tgz",
       "integrity": "sha512-JRc/v+OBH0qLTdvQ7HvHWTxGJH73QOf1MC0R8NhOX2QnAbg2mPFv1h+FjGa2gfLGuCXBdWQomjekWkUKbC4e5A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5484,7 +5465,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.1.tgz",
       "integrity": "sha512-6kCiGLvpES4AxcEuOhb7HR7/xIeJWMjZlb6J7e8zpiIh5BoQc7NoRdctsnmFEjZvC19bIasccshHQ7H2zchWqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -5748,7 +5728,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -6326,7 +6305,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -6590,7 +6568,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6883,7 +6860,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -8220,7 +8196,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -8231,7 +8206,6 @@
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8641,6 +8615,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -8721,7 +8696,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -8930,6 +8904,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -9228,7 +9203,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -9463,7 +9437,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -10539,7 +10512,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10744,7 +10716,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -10774,7 +10745,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -10823,7 +10793,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
       "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -11157,7 +11126,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11798,8 +11766,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -11984,8 +11951,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -12201,7 +12167,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12277,7 +12242,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -12826,7 +12790,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noteflow",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "A web-based note-taking application inspired by Microsoft OneNote",
   "workspaces": [

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -230,6 +230,38 @@ export interface TaggedNoteDto {
   updatedAt: string;
 }
 
+// ── Recycle Bin DTOs ────────────────────────────────────────────
+
+export interface DeletedNotebookDto {
+  id: number;
+  title: string;
+  deletedAt: string;
+}
+
+export interface DeletedSectionDto {
+  id: number;
+  title: string;
+  notebookId: number;
+  notebookTitle: string;
+  deletedAt: string;
+}
+
+export interface DeletedNoteDto {
+  id: number;
+  title: string;
+  sectionId: number;
+  sectionTitle: string;
+  notebookId: number;
+  notebookTitle: string;
+  deletedAt: string;
+}
+
+export interface RecycleBinDto {
+  notebooks: DeletedNotebookDto[];
+  sections: DeletedSectionDto[];
+  notes: DeletedNoteDto[];
+}
+
 // ── Note Link DTOs ──────────────────────────────────────────────
 
 export interface NoteLinkContextDto {


### PR DESCRIPTION
## Summary
Implements a Recycle Bin feature that soft-deletes notebooks, sections, and notes instead of permanently removing them. Deleted items are retained for 30 days before automatic purging, and users can restore or permanently delete items from a dedicated Recycle Bin panel.

## Key Changes

### Backend
- **Database Migration**: Added `deletedAt` column to Notebook, Section, and Note tables for soft-delete support
- **Recycle Bin Service** (`apps/api/src/services/recycle-bin.service.ts`):
  - `getDeletedItems()`: Retrieves soft-deleted items organized by type, excluding cascade-deleted children
  - `restoreNotebook/Section/Note()`: Restores deleted items and their parents if needed
  - `permanentlyDeleteNotebook/Section/Note()`: Permanently removes items from recycle bin
  - `emptyRecycleBin()`: Clears all soft-deleted items for a user
  - `purgeExpiredItems()`: Scheduled job to permanently delete items older than 30 days
- **Updated Services**: Modified notebook, section, and note services to filter out soft-deleted items in queries
- **API Routes** (`apps/api/src/routes/recycle-bin.routes.ts`): New endpoints for recycle bin operations
- **Cron Job**: Integrated `purgeExpiredItems()` into daily account purge schedule

### Frontend
- **Recycle Bin Panel** (`apps/web/src/app/features/shell/recycle-bin-panel/recycle-bin-panel.ts`):
  - Displays deleted notebooks, sections, and notes organized by type
  - Shows days remaining before permanent deletion (30-day countdown)
  - Restore and permanent delete buttons for each item
  - Empty entire recycle bin with confirmation
  - Loading and empty states
- **Recycle Bin Service** (`apps/web/src/app/core/services/recycle-bin.service.ts`): HTTP client for recycle bin operations
- **Toast Notifications**: New `ToastService` and `ToastContainer` for undo actions
- **Shell Integration**: 
  - Added recycle bin panel to shell component
  - Added trash icon to navigation rail for quick access
  - Updated delete operations to show toast with undo capability
  - Modified `ShellStateService` to trigger restore on undo
- **UI Updates**: Updated help panel and release notes with recycle bin documentation
- **Version Bump**: Updated to v0.8.0

### Shared Types
- Added DTOs: `DeletedNotebookDto`, `DeletedSectionDto`, `DeletedNoteDto`, `RecycleBinDto`

## Implementation Details
- Soft-delete queries exclude deleted items by default (`deletedAt IS NULL` filters)
- Recycle bin queries explicitly include deleted items (`deletedAt IS NOT NULL`)
- Cascade restoration: restoring a section/note also restores its parent if deleted
- Toast notifications provide undo functionality for 5 seconds after deletion
- 30-day retention period enforced via daily cron job

https://claude.ai/code/session_013UKZHKkGejSTv5pVzPfCNG